### PR TITLE
Make the formula fully pillar driven/customizable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,13 +10,14 @@ Here's a small pillar data sample::
     sysctl:
       lookup:
         pkg: procps-ng
-        config_location: /etc/sysctl.d
-      params:
-        vm.swappines: 
-          value: 20
-          config: 10-swap.conf
-        fs.file-max: 
-          value: 10000
+        config:
+          location: /etc/sysctl.d
+        params:
+          vm.swappines: 
+            value: 20
+            config: 10-swap.conf
+          fs.file-max: 
+            value: 10000
 
 
 The state sysclt will ensure these are present on the system

--- a/pillar.example
+++ b/pillar.example
@@ -1,11 +1,13 @@
 sysctl:
   lookup:
     pkg: procps-ng
-  params:
-    fs.file-max: 
-      value: 100000
-      config: fs.conf
-    vm.swappiness:
-      value: 20
-
-
+    config:
+      location: '/etc/sysctl.d'
+    params:
+      - 
+        name: fs.file-max
+        value: 100000
+        config: fs.conf
+      - 
+        name: vm.swappiness
+        value: 20

--- a/sysctl/defaults.yml
+++ b/sysctl/defaults.yml
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+sysctl:
+  pkg: procps-ng
+  config:
+    location: '/etc/sysctl.d'
+  params:
+    - 
+      name: fs.file-max
+      value: 100000
+      config: fs.conf
+    - 
+      name: vm.swappiness
+      value: 20

--- a/sysctl/init.sls
+++ b/sysctl/init.sls
@@ -1,23 +1,6 @@
-{% from "sysctl/map.jinja" import sysctl with context %}
+# -*- coding: utf-8 -*-
+# vim: ft=sls
 
-sysctl:
-  pkg.installed:
-    - name: {{ sysctl.pkg|json }}
-
-{%- set config = pillar.get("sysctl", {} )%}
-{%- for name, item in config.get('params', {}).items() %}
-{%- if item == None -%}
-{% set item = {} -%}
-{%- endif -%}
-{%- set value = item.get('value', {}) %}
-{%- set config = item.get('config') %}
-
-{{ name }}:
-  sysctl.present:
-    - name: {{ name }}
-    - value: {{ value }}
-    {%- if 'config' in item %}
-    - config: {{ sysctl.config_location}}/{{ config }}
-    {%- endif %}
-{%- endfor -%}
-
+include:
+  - sysctl.package
+  - sysctl.param

--- a/sysctl/map.jinja
+++ b/sysctl/map.jinja
@@ -1,6 +1,25 @@
-{% set sysctl = salt['grains.filter_by']({
-  'Arch': {
-    'pkg'             : 'procps-ng',
-    'config_location' : '/etc/sysctl.d',
-  },
-}, merge=salt['pillar.get']('sysctl:lookup')) %}
+# -*- coding: utf-8 -*-
+# vim: ft=jinja
+
+{## Start with  defaults from defaults.sls ##}
+{% import_yaml 'sysctl/defaults.yml' as default_settings %}
+
+{## setup variable using grains['os_family'] based logic ##}
+{% set os_family_map = salt['grains.filter_by']({
+        'Arch': {
+            "config": {
+                "location": '/etc/sysctl.d',
+            }
+        }
+  }, grain="os_family")
+%}
+{## Merge the flavor_map to the default settings ##}
+{% do default_settings.sysctl.update(os_family_map) %}
+
+{## Merge in sysctl:lookup pillar ##}
+{% set sysctl_settings = salt['pillar.get'](
+        'sysctl:lookup',
+        default=default_settings.sysctl,
+        merge=True
+    )
+%}

--- a/sysctl/package.sls
+++ b/sysctl/package.sls
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{## import settings from map.jinja ##}
+{% from "sysctl/map.jinja" import sysctl_settings with context %}
+
+sysctl-pkg:
+  pkg.installed:
+    - name: {{ sysctl_settings.pkg }}
+    - failhard: True

--- a/sysctl/param.sls
+++ b/sysctl/param.sls
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{## import settings from map.jinja ##}
+{% from "sysctl/map.jinja" import sysctl_settings with context %}
+
+{% for param in  sysctl_settings.get('params', {}) %}
+  {% if param is mapping %}
+sysctl-present-{{ param.name }}:
+  sysctl.present:
+    - name: {{ param.name }}
+    - value: {{ param.version }}
+    {% if param.config is defined %}
+    - config: {{ sysctl_settings.config.location }}/{{ param.config }}
+    {% endif %}
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
**Summary**
- split package and param into separate state files
- use defaults.yml to specify all configurable options of the formula
- setup map.jinja to read in defaults.yml, filter by os_family for
  Arch, and merge in sysctl:lookup pillar
- Updated README
