### PR TITLE
Fixed a typo and added RedHat family to map.jinja

### DIFF
--- a/sysctl/map.jinja
+++ b/sysctl/map.jinja
@@ -10,6 +10,11 @@
             "config": {
                 "location": '/etc/sysctl.d',
             }
+        },
+        'RedHat': {
+            "config": {
+                "location": '/etc/sysctl.conf',
+            }
         }
   }, grain="os_family")
 %}

--- a/sysctl/param.sls
+++ b/sysctl/param.sls
@@ -9,7 +9,7 @@
 sysctl-present-{{ param.name }}:
   sysctl.present:
     - name: {{ param.name }}
-    - value: {{ param.version }}
+    - value: {{ param.value }}
     {% if param.config is defined %}
     - config: {{ sysctl_settings.config.location }}/{{ param.config }}
     {% endif %}


### PR DESCRIPTION
Formula was failing on my clean Centos 6.5 install and I tracked the errors to some typos and missing RedHat family in map.jinja.
