### PR TITLE
Added support to specify params as dictionary (as a params2)

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -11,3 +11,10 @@ sysctl:
       - 
         name: vm.swappiness
         value: 20
+    # Setting params2 excludes all params values
+    params2:
+      fs.file-max:
+        value: 100000
+        config: fs.conf
+      vm.swappiness:
+        value: 20

--- a/sysctl/param.sls
+++ b/sysctl/param.sls
@@ -4,14 +4,32 @@
 {## import settings from map.jinja ##}
 {% from "sysctl/map.jinja" import sysctl_settings with context %}
 
-{% for param in  sysctl_settings.get('params', {}) %}
-  {% if param is mapping %}
+{% if sysctl_settings.get('params2', '') != '' %}
+
+  {% for param_name, param in sysctl_settings.get('params2', {}).items() %}
+    {% if param is mapping %}
+sysctl-present-{{ param_name }}:
+  sysctl.present:
+    - name: {{ param_name }}
+    - value: {{ param.value }}
+      {% if param.config is defined %}
+    - config: {{ sysctl_settings.config.location }}/{{ param.config }}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+
+{% else %}
+
+  {% for param in  sysctl_settings.get('params', {}) %}
+    {% if param is mapping %}
 sysctl-present-{{ param.name }}:
   sysctl.present:
     - name: {{ param.name }}
     - value: {{ param.value }}
-    {% if param.config is defined %}
+      {% if param.config is defined %}
     - config: {{ sysctl_settings.config.location }}/{{ param.config }}
+      {% endif %}
     {% endif %}
-  {% endif %}
-{% endfor %}
+  {% endfor %}
+
+{% endif %}

--- a/sysctl/param.sls
+++ b/sysctl/param.sls
@@ -2,34 +2,34 @@
 # vim: ft=sls
 
 {## import settings from map.jinja ##}
-{% from "sysctl/map.jinja" import sysctl_settings with context %}
+{%- from "sysctl/map.jinja" import sysctl_settings with context -%}
 
-{% if sysctl_settings.params2 is defined %}
+{%- if sysctl_settings.params2 is defined -%}
 
-  {% for param_name, param in sysctl_settings.get('params2', {}).items() %}
-    {% if param is mapping %}
+  {%- for param_name, param in sysctl_settings.get('params2', {}).items() -%}
+    {%- if param is mapping %}
 sysctl-present-{{ param_name }}:
   sysctl.present:
     - name: {{ param_name }}
     - value: {{ param.value }}
-      {% if param.config is defined %}
+      {%- if param.config is defined %}
     - config: {{ sysctl_settings.config.location }}/{{ param.config }}
-      {% endif %}
-    {% endif %}
+      {% endif -%}
+    {% endif -%}
   {% endfor %}
 
 {% else %}
 
-  {% for param in  sysctl_settings.get('params', {}) %}
-    {% if param is mapping %}
+  {%- for param in  sysctl_settings.get('params', {}) -%}
+    {%- if param is mapping %}
 sysctl-present-{{ param.name }}:
   sysctl.present:
     - name: {{ param.name }}
     - value: {{ param.value }}
-      {% if param.config is defined %}
+      {%- if param.config is defined %}
     - config: {{ sysctl_settings.config.location }}/{{ param.config }}
-      {% endif %}
-    {% endif %}
+      {% endif -%}
+    {% endif -%}
   {% endfor %}
 
-{% endif %}
+{%- endif -%}

--- a/sysctl/param.sls
+++ b/sysctl/param.sls
@@ -4,7 +4,7 @@
 {## import settings from map.jinja ##}
 {% from "sysctl/map.jinja" import sysctl_settings with context %}
 
-{% if sysctl_settings.get('params2', '') != '' %}
+{% if sysctl_settings.params2 is defined %}
 
   {% for param_name, param in sysctl_settings.get('params2', {}).items() %}
     {% if param is mapping %}


### PR DESCRIPTION
Based on discussion in ticket #9 
Specifying params as dictionary can be done via params2 variable, see pillar.example for details. For backward compatibility specifying params as array still works via params variable and it remains default. If users specifies params2 in pillar all values under params are ignored.
