### PR TITLE
Switch to cleaner pillar structure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,37 @@
+==============
 sysctl-formula
 ==============
 
 This formula ensures that a sysctl parameter is present on the system
-from a pillar file.
+based on configuration in pillars.
 
-Please check pillar.example for usage example.
+Values are written to ``/etc/sysctl.d/99-salt.conf`` or ``/etc/sysctl.conf`` for
+systemd or sysvinit systems respectively. This can be overriden by explicitly
+passing the ``config`` parameter.
 
-The state sysctl will ensure these are present on the system
-based on the sysctl module of salt. 
+.. note::
 
-if no config value is given the key value will be written based host system.
-on systemd systems this will be /etc/sysctl.d/99-salt.conf
-on sysv init systems it will be /etc/sysctl.conf
+    See the full `Salt Formulas installation and usage instructions
+    <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
+Available states
+================
+
+.. contents::
+    :local:
+
+``sysctl``
+----------
+
+Meta-state that includes both the ``sysctl.package`` and ``sysctl.param`` states.
+
+``sysctl.package``
+------------------
+
+Ensures that the ``sysctl`` program is available.
+
+``sysctl.param``
+----------------
+
+Sets sysctl values from configuration in pillars data using
+`sysctl.present <https://docs.saltstack.com/en/latest/ref/states/all/salt.states.sysctl.html#salt.states.sysctl.present>`_.

--- a/pillar.example
+++ b/pillar.example
@@ -3,18 +3,8 @@ sysctl:
     pkg: procps-ng
     config:
       location: '/etc/sysctl.d'
-    params:
-      - 
-        name: fs.file-max
-        value: 100000
-        config: fs.conf
-      - 
-        name: vm.swappiness
-        value: 20
-    # Setting params2 excludes all params values
-    params2:
-      fs.file-max:
-        value: 100000
-        config: fs.conf
-      vm.swappiness:
-        value: 20
+  params:
+    fs.file-max:
+      value: 100000
+      config: fs.conf
+    vm.swappiness: 20

--- a/sysctl/defaults.yml
+++ b/sysctl/defaults.yml
@@ -4,11 +4,12 @@ sysctl:
   pkg: procps-ng
   config:
     location: '/etc/sysctl.d'
-  params:
-    - 
-      name: fs.file-max
-      value: 100000
-      config: fs.conf
-    - 
-      name: vm.swappiness
-      value: 20
+  lookup:
+    params:
+      -
+        name: fs.file-max
+        value: 100000
+        config: fs.conf
+      -
+        name: vm.swappiness
+        value: 20

--- a/sysctl/map.jinja
+++ b/sysctl/map.jinja
@@ -4,6 +4,16 @@
 {## Start with  defaults from defaults.sls ##}
 {% import_yaml 'sysctl/defaults.yml' as default_settings %}
 
+{% set sysctl_lookup = salt['pillar.get']('sysctl:lookup', {}).copy() %}
+
+{% if sysctl_lookup.params is defined %}
+{% do sysctl_lookup.pop('params') %}
+{% endif %}
+
+{% if sysctl_lookup.params2 is defined %}
+{% do sysctl_lookup.pop('params2') %}
+{% endif %}
+
 {## setup variable using grains['os_family'] based logic ##}
 {% set os_family_map = salt['grains.filter_by']({
         'Arch': {
@@ -28,14 +38,17 @@
                 "location": '/etc/sysctl.d',
              }
          },
-  }, grain="os_family")
+  },
+  grain="os_family",
+  merge=sysctl_lookup)
 %}
+
 {## Merge the flavor_map to the default settings ##}
 {% do default_settings.sysctl.update(os_family_map) %}
 
-{## Merge in sysctl:lookup pillar ##}
+{## Merge in sysctl pillar ##}
 {% set sysctl_settings = salt['pillar.get'](
-        'sysctl:lookup',
+        'sysctl',
         default=default_settings.sysctl,
         merge=True
     )

--- a/sysctl/param.sls
+++ b/sysctl/param.sls
@@ -4,32 +4,51 @@
 {## import settings from map.jinja ##}
 {%- from "sysctl/map.jinja" import sysctl_settings with context -%}
 
-{%- if sysctl_settings.params2 is defined -%}
-
-  {%- for param_name, param in sysctl_settings.get('params2', {}).items() -%}
-    {%- if param is mapping %}
+{% if sysctl_settings.params is defined %}
+  {% for param_name, param in sysctl_settings.get('params').items() %}
+    {% if param is mapping %}
 sysctl-present-{{ param_name }}:
   sysctl.present:
     - name: {{ param_name }}
     - value: {{ param.value }}
-      {%- if param.config is defined %}
+        {%- if param.config is defined %}
     - config: {{ sysctl_settings.config.location }}/{{ param.config }}
-      {% endif -%}
-    {% endif -%}
+        {% endif -%}
+    {% else %}
+sysctl-present-{{ param_name }}:
+  sysctl.present:
+    - name: {{ param_name }}
+    - value: {{ param }}
+    {% endif %}
   {% endfor %}
-
 {% else %}
+{## Support for legacy pillar structure ##}
+  {%- if sysctl_settings.lookup.params2 is defined -%}
 
-  {%- for param in  sysctl_settings.get('params', {}) -%}
+    {%- for param_name, param in sysctl_settings.lookup.get('params2', {}).items() -%}
+      {%- if param is mapping %}
+sysctl-present-{{ param_name }}:
+  sysctl.present:
+    - name: {{ param_name }}
+    - value: {{ param.value }}
+        {%- if param.config is defined %}
+    - config: {{ sysctl_settings.config.location }}/{{ param.config }}
+        {% endif -%}
+      {% endif -%}
+    {% endfor %}
+
+  {% else %}
+
+    {%- for param in  sysctl_settings.lookup.get('params', {}) -%}
     {%- if param is mapping %}
 sysctl-present-{{ param.name }}:
   sysctl.present:
     - name: {{ param.name }}
     - value: {{ param.value }}
-      {%- if param.config is defined %}
+        {%- if param.config is defined %}
     - config: {{ sysctl_settings.config.location }}/{{ param.config }}
+        {% endif -%}
       {% endif -%}
-    {% endif -%}
-  {% endfor %}
-
+    {% endfor %}
+  {%- endif -%}
 {%- endif -%}


### PR DESCRIPTION
This commit allows users to specify sysctl parameters in an easier
format than the one that was used before. It moves settings out of the
'lookup' pillar namespace in a backward compatible manner and is
modelled after the old 'params2' approach.

It also introduces a simplified scheme, in which parameters can be
specified as key-value pairs, which makes for cleaner pillars if there
is no need to specify a custom configuration file.
