### PR TITLE
Don't set fs.file-max and vm.swappiness by default

### DIFF
--- a/sysctl/defaults.yml
+++ b/sysctl/defaults.yml
@@ -4,12 +4,3 @@ sysctl:
   pkg: procps-ng
   config:
     location: '/etc/sysctl.d'
-  lookup:
-    params:
-      -
-        name: fs.file-max
-        value: 100000
-        config: fs.conf
-      -
-        name: vm.swappiness
-        value: 20


### PR DESCRIPTION
Users can easily configure this themselves and it it strongly preferred
if idiosyncratic changes such as this are not part of the default
behaviour.

This is a backward incompatible PR in that it changes the default behaviour of the formula and users who relied on it will have to change their pillars to include the entries removed here.
