### PR TITLE
Revert "Remove redundant entries from map.jinja file"

### DIFF
--- a/sysctl/map.jinja
+++ b/sysctl/map.jinja
@@ -16,6 +16,11 @@
 
 {## setup variable using grains['os_family'] based logic ##}
 {% set os_family_map = salt['grains.filter_by']({
+        'Arch': {
+            "config": {
+                "location": '/etc/sysctl.d',
+            }
+        },
         'RedHat': {
             "config": {
                 "location": '/etc/sysctl.conf',
@@ -23,9 +28,15 @@
         },
         'Suse': {
             "pkg": "procps",
+            "config": {
+                "location": '/etc/sysctl.d',
+            }
         },
         'Debian': {
             "pkg": "procps",
+            "config": {
+                "location": '/etc/sysctl.d',
+             }
          },
   },
   grain="os_family",


### PR DESCRIPTION
Reverts saltstack-formulas/sysctl-formula#13

There is an issue with this:

```
    Rendering SLS 'base:sysctl.package' failed: Jinja error: 'NoneType' object is not iterable
/var/cache/salt/minion/files/base/sysctl/map.jinja(36):

---
[...]
  grain="os_family",
  merge=sysctl_lookup)
%}

{## Merge the flavor_map to the default settings ##}
{% do default_settings.sysctl.update(os_family_map) %}    <======================

{## Merge in sysctl pillar ##}
{% set sysctl_settings = salt['pillar.get'](
        'sysctl',
        default=default_settings.sysctl,
[...]

---
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/templates.py", line 366, in render_jinja_tmpl
    output = template.render(**decoded_context)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 5, in top-level template code
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 1033, in make_module
    return TemplateModule(self, self.new_context(vars, shared, locals))
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 1090, in __init__
    self._body_stream = list(template.root_render_func(context))
  File "/var/cache/salt/minion/files/base/sysctl/map.jinja", line 36, in top-level template code
    {% do default_settings.sysctl.update(os_family_map) %}
TypeError: 'NoneType' object is not iterable


----------
    Rendering SLS 'base:sysctl.param' failed: Jinja error: 'NoneType' object is not iterable
/var/cache/salt/minion/files/base/sysctl/map.jinja(36):

---
[...]
  grain="os_family",
  merge=sysctl_lookup)
%}

{## Merge the flavor_map to the default settings ##}
{% do default_settings.sysctl.update(os_family_map) %}    <======================

{## Merge in sysctl pillar ##}
{% set sysctl_settings = salt['pillar.get'](
        'sysctl',
        default=default_settings.sysctl,
[...]

---
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/templates.py", line 366, in render_jinja_tmpl
    output = template.render(**decoded_context)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 5, in top-level template code
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 1033, in make_module
    return TemplateModule(self, self.new_context(vars, shared, locals))
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 1090, in __init__
    self._body_stream = list(template.root_render_func(context))
  File "/var/cache/salt/minion/files/base/sysctl/map.jinja", line 36, in top-level template code
    {% do default_settings.sysctl.update(os_family_map) %}
TypeError: 'NoneType' object is not iterable
```
