### PR TITLE
Check for presence of 'lookup' key

### DIFF
--- a/sysctl/param.sls
+++ b/sysctl/param.sls
@@ -23,32 +23,33 @@ sysctl-present-{{ param_name }}:
   {% endfor %}
 {% else %}
 {## Support for legacy pillar structure ##}
-  {%- if sysctl_settings.lookup.params2 is defined -%}
-
-    {%- for param_name, param in sysctl_settings.lookup.get('params2', {}).items() -%}
-      {%- if param is mapping %}
+  {%- if sysctl_settings.lookup is defined %}
+    {% if sysctl_settings.lookup.params2 is defined -%}
+      {%- for param_name, param in sysctl_settings.lookup.get('params2', {}).items() -%}
+        {%- if param is mapping %}
 sysctl-present-{{ param_name }}:
   sysctl.present:
     - name: {{ param_name }}
     - value: {{ param.value }}
-        {%- if param.config is defined %}
+          {%- if param.config is defined %}
     - config: {{ sysctl_settings.config.location }}/{{ param.config }}
+          {% endif -%}
         {% endif -%}
-      {% endif -%}
-    {% endfor %}
+      {% endfor %}
 
-  {% else %}
+    {% else %}
 
-    {%- for param in  sysctl_settings.lookup.get('params', {}) -%}
-    {%- if param is mapping %}
+      {%- for param in  sysctl_settings.lookup.get('params', {}) -%}
+        {%- if param is mapping %}
 sysctl-present-{{ param.name }}:
   sysctl.present:
     - name: {{ param.name }}
     - value: {{ param.value }}
         {%- if param.config is defined %}
     - config: {{ sysctl_settings.config.location }}/{{ param.config }}
+          {% endif -%}
         {% endif -%}
-      {% endif -%}
-    {% endfor %}
+      {% endfor %}
+    {% endif -%}
   {%- endif -%}
 {%- endif -%}


### PR DESCRIPTION
Access to this key might have failed otherwise when the user specifies
no pillar.
